### PR TITLE
Sanitize HTML characters when logging subprocess output

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -65,7 +65,7 @@ class LoggerInWorkspace {
         }
         const element = document.createElement('pre');
         element.className = 'stdout';
-        element.innerHTML = message;
+        element.innerHTML = this.escapeHtml(message);
         return this.addMessage(element, false);
     }
     stderr(message) {
@@ -74,8 +74,19 @@ class LoggerInWorkspace {
         }
         const element = document.createElement('pre');
         element.className = 'stderr';
-        element.innerHTML = message;
+        element.innerHTML = this.escapeHtml(message);
         return this.addMessage(element, true);
+    }
+    escapeHtml(message) {
+        if (typeof message === 'object') {
+            message = message.toString();
+        }
+        return message
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#039;");
     }
     addMessage(element, error) {
         if (error) {

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -56,7 +56,7 @@ class LoggerInWorkspace {
         }
         const element = document.createElement('pre');
         element.className = 'stdin';
-        element.innerHTML = message;
+        element.innerHTML = this.escapeHtml(message);
         return this.addMessage(element, false);
     }
     stdout(message) {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -93,7 +93,7 @@ export class LoggerInWorkspace implements Logger, ViewModel {
 
 		const element = document.createElement('pre');
 		element.className = 'stdout';
-		element.innerHTML = message;
+		element.innerHTML = this.escapeHtml(message);
 
 		return this.addMessage(element, false);
 	}
@@ -105,10 +105,23 @@ export class LoggerInWorkspace implements Logger, ViewModel {
 
 		const element = document.createElement('pre');
 		element.className = 'stderr';
-		element.innerHTML = message;
+		element.innerHTML = this.escapeHtml(message);
 
 		return this.addMessage(element, true);
 	}
+
+	private escapeHtml(message: string) {
+		if (typeof message === 'object') {
+			message = message!.toString();
+		}
+		return message
+			 .replace(/&/g, "&amp;")
+			 .replace(/</g, "&lt;")
+			 .replace(/>/g, "&gt;")
+			 .replace(/"/g, "&quot;")
+			 .replace(/'/g, "&#039;");
+ 	}
+
 
 	private addMessage(element: HTMLElement, error: boolean) {
 		if (error) {

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -81,7 +81,7 @@ export class LoggerInWorkspace implements Logger, ViewModel {
 
 		const element = document.createElement('pre');
 		element.className = 'stdin';
-		element.innerHTML = message;
+		element.innerHTML = this.escapeHtml(message);
 
 		return this.addMessage(element, false);
 	}


### PR DESCRIPTION
Hi, I've found this bug by trying to print the active players using 
```python
print(Clock)
```
Players are represented in this format: `<h1 - play>`, `<jb - jbass>`, and atom thinks it's an HTML markup, so the output was messed up:

![Selection_999(076)](https://user-images.githubusercontent.com/15896005/104116439-d30b8480-5318-11eb-894d-d815f8801af0.png)

You can also do other silly things with it ofc

![Selection_999(079)](https://user-images.githubusercontent.com/15896005/104116394-6b553980-5318-11eb-9011-013b989cec17.png)

This PR fixes the printing of Player objects, but you can still embed code... I gues this is Atom's issue?

![Selection_999(081)](https://user-images.githubusercontent.com/15896005/104116657-dacc2880-531a-11eb-9b83-3cb4df5e2c6d.png)


